### PR TITLE
Fix: Added necessary config to run the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-webpack": "^1.8.0",
     "node-static": "^0.7.9",
     "raw-loader": "^0.5.1",
-    "typescript": "^2.0.3",
+    "typescript": "2.0.10",
     "webpack": "^2.1.0-beta.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "zone.js": "^0.6.26"
   },
   "devDependencies": {
+    "@types/jasmine": "2.5.35",
     "@types/node": "^6.0.45",
     "@types/webpack-env": "^1.12.1",
     "angular2-template-loader": "^0.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,12 @@
+const path = require('path');
+
 module.exports = () => {
     return {
         entry: {
-            main: './src/main.ts'
+            main: path.resolve(__dirname, './src/main.ts')
         },
         output: {
-            path: './dist',
+            path: path.resolve(__dirname, './dist'),
             filename: '[name].bundle.js'
         },
         resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = () => {
                 },
                 {
                     test: /\.html$/,
-                    loader: 'raw'
+                    loader: 'raw-loader'
                 }
             ]
         },


### PR DESCRIPTION
Closes #2 

Description:
The current build is crashing after installing the required deps. I've modified the less amount of code possible to make a running build once again.

This PR is using outdated packages, only minimal/patch versions were bumped. I've tested this config bumping all requirements (NG4+) and it worked. I'm not including them here, but I can open another PR if desired.

Tested on Node v8.1.4 (npm v5.3.0) and also v6.11.1 (npm v3.10.10) LTS.